### PR TITLE
Run backups on dedicated connection pool

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -723,6 +723,12 @@ func (instance *Instance) GetSuperUserDB() (*sql.DB, error) {
 	return instance.ConnectionPool().Connection("postgres")
 }
 
+// GetBackgroundDB returns a connection to the instance that should be used for long running
+// background processes such as creating backups.
+func (instance *Instance) GetBackgroundDB() (*sql.DB, error) {
+	return instance.ConnectionPool().Connection("postgres")
+}
+
 // GetTemplateDB gets a connection to the "template1" database on this instance
 func (instance *Instance) GetTemplateDB() (*sql.DB, error) {
 	return instance.ConnectionPool().Connection("template1")
@@ -902,7 +908,7 @@ func (instance *Instance) WaitForConfigReload(ctx context.Context) (*postgres.Po
 		return nil, fmt.Errorf("while waiting for new configuration to be reloaded: %w", err)
 	}
 
-	status, err := instance.GetStatus()
+	status, err := instance.GetStatus(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("while applying new configuration: %w", err)
 	}

--- a/pkg/management/postgres/webserver/backup_connection.go
+++ b/pkg/management/postgres/webserver/backup_connection.go
@@ -104,7 +104,7 @@ func newBackupConnection(
 	immediateCheckpoint bool,
 	waitForArchive bool,
 ) (*backupConnection, error) {
-	superUserDB, err := instance.GetSuperUserDB()
+	superUserDB, err := instance.GetBackgroundDB()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/management/upgrade/upgrade.go
+++ b/pkg/management/upgrade/upgrade.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"syscall"
+	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,7 +84,10 @@ func FromLocalBinary(
 	}(sourceFile)
 
 	// Gather the status of the instance
-	instanceStatus, err := instance.GetStatus()
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	defer cancel()
+
+	instanceStatus, err := instance.GetStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("while retrieving instance's status: %w", err)
 	}
@@ -162,8 +166,12 @@ func FromReader(
 				"name", updatedInstanceManager.Name(), "err", err)
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 5 * time.Minute)
+	defer cancel()
+
 	// Gather the status of the instance
-	instanceStatus, err := instance.GetStatus()
+	instanceStatus, err := instance.GetStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("while retrieving instance's status: %w", err)
 	}


### PR DESCRIPTION
Every long running backup consumes a connection from the super user
connection pool for the complete duration of the backup. Since that
pool only has a maximum of 3 open connections, it is easy to
accidentally consume all super user connections with backups. This
deadlocks other processes that need the super user connection, such as
running the status probe.

Solve this by using a dedicated pool for backups, and while here
deduplicate concurrent status probes so that they produce less of what
little load they produced anyway.

`nbraun` on the Gophers Slack put the puzzle pieces together on this one,
I just opened the box.