### PR TITLE
fix: actually use a separate pool for background connections

### DIFF
--- a/pkg/management/postgres/instance.go
+++ b/pkg/management/postgres/instance.go
@@ -726,7 +726,7 @@ func (instance *Instance) GetSuperUserDB() (*sql.DB, error) {
 // GetBackgroundDB returns a connection to the instance that should be used for long running
 // background processes such as creating backups.
 func (instance *Instance) GetBackgroundDB() (*sql.DB, error) {
-	return instance.ConnectionPool().Connection("postgres")
+	return instance.ConnectionPool().BackgroundConnection("postgres")
 }
 
 // GetTemplateDB gets a connection to the "template1" database on this instance

--- a/pkg/management/postgres/webserver/backup_connection.go
+++ b/pkg/management/postgres/webserver/backup_connection.go
@@ -104,18 +104,18 @@ func newBackupConnection(
 	immediateCheckpoint bool,
 	waitForArchive bool,
 ) (*backupConnection, error) {
-	superUserDB, err := instance.GetBackgroundDB()
+	db, err := instance.GetBackgroundDB()
 	if err != nil {
 		return nil, err
 	}
 
-	vers, err := utils.GetPgVersion(superUserDB)
+	vers, err := utils.GetPgVersion(db)
 	if err != nil {
 		return nil, err
 	}
 
 	// the context is used only while obtaining the connection
-	conn, err := superUserDB.Conn(ctx)
+	conn, err := db.Conn(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The way connections are cached meant that the previous patch for using a dedicated background pool didn't actually work: it re-used the main pool.

Mitigate that by tracking a "is a background pool" flag in addition to the actual DB name.